### PR TITLE
Update response handling to cope with ElasticSearch v1.x

### DIFF
--- a/bzcache/bzcache.py
+++ b/bzcache/bzcache.py
@@ -42,10 +42,13 @@ class BugzillaCache(object):
   def _add_doc(self, doc, id=None):
     result = self.eslib.add_doc(doc, id, doc_type=self.doc_type)
 
-    if not 'ok' in result or not result['ok'] or not '_id' in result:
-      raise Exception(json.dumps(result))
+    # ElasticSearch v1.x uses 'created', v0.9 uses 'ok'
+    created = result.get('created', False) or result.get('ok', False)
 
-    return result['_id']
+    if created and '_id' in result:
+      return result['_id']
+
+    raise Exception(json.dumps(result))
 
   def index_bugs_by_keyword(self, keyword):
     # only look at bugs that have been updated in the last 6 months

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 import sys
 from setuptools import setup, find_packages
 
-version = '0.1.1'
+version = '0.1.2'
 
 deps = ['mozautoeslib']
 


### PR DESCRIPTION
ElasticSearch v1.x no longer returns 'ok', due to:
https://github.com/elasticsearch/elasticsearch/commit/d23f640cd1488727c8337a888527d662c6135fac

Ideally we should be checking the HTTP response code, but bzcache uses mozautoeslib, which in turn uses an ancient version of pyes - and it's not worth delving into that rabbit hole. This solution isn't elegant, but should work for now until OrangeFactor is end of lifed.