### PR TITLE
Bug 1301107 - Paginate Bugzilla requests to prevent timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.egg-info
+*.py[co]
+__pycache__
+dist/

--- a/bzcache/bz_cache_refresh.py
+++ b/bzcache/bz_cache_refresh.py
@@ -2,10 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import datetime
-import urllib
-import urlparse
-
 from pyes import ES
 from pyes.exceptions import ElasticSearchException
 
@@ -27,24 +23,6 @@ def main(options):
     bzcache = BugzillaCache(es_server=options.es_server)
     bzcache.index_bugs_by_keyword('intermittent-failure')
 
-    # Now, request an API from the WOO server that will cause all the bugs
-    # relevant to WOO to be re-inserted into the cache.
-
-    # calculate the startday and endday parameters
-    today = datetime.date.today()
-    earlier = today - datetime.timedelta(60)
-    of_parsed_url = urlparse.urlparse(options.of_server)
-    of_base_url = '%s://%s%s%s' % (of_parsed_url.scheme or 'http',
-                                   of_parsed_url.netloc,
-                                   of_parsed_url.path,
-                                   '/' if of_parsed_url.path[-1] != '/' else '')
-    of_url = "%sbybug?startday=%s&endday=%s&tree=All" % \
-        (of_base_url, str(earlier), str(today))
-    print datetime.datetime.now(), of_url
-
-    # retrieve the url
-    data = urllib.urlopen(of_url)
-    data.read()
 
 if __name__ == "__main__":
   import optparse

--- a/bzcache/bz_cache_refresh.py
+++ b/bzcache/bz_cache_refresh.py
@@ -7,16 +7,21 @@ import urllib
 import urlparse
 
 from pyes import ES
+from pyes.exceptions import ElasticSearchException
 
 import config
 from bzcache import BugzillaCache
 
 
 def main(options):
-    # delete and re-create the bzcache index, in order to nuke its contents
     es = ES([options.es_server])
-    es.delete_index('bzcache')
-    es.create_index('bzcache')
+    try:
+        es.create_index_if_missing('bzcache')
+    except ElasticSearchException:
+        # create_index_if_missing is supposed not to raise if the index
+        # already existing, but with the ancient pyes / ES server versions
+        # we're using it still does.
+        pass
 
     # re-cache all intermittent-failure bugs
     bzcache = BugzillaCache(es_server=options.es_server)

--- a/bzcache/bzcache.py
+++ b/bzcache/bzcache.py
@@ -95,14 +95,10 @@ class BugzillaCache(object):
                                  False)
 
   def _get_bugzilla_data(self, bugid_array):
-    retVal = {}
-
     apiURL = (self.bzapi_server + "bug?id=" + ','.join(bugid_array) +
               "&include_fields=id,summary,status,whiteboard")
     bugdict = self.fetch_json(apiURL).get('bugs', [])
-    for bug in bugdict:
-        retVal[bug['id']] = bug
-    return retVal
+    return bugdict
 
   def get_bugs(self, bugids):
     bugs = {}
@@ -130,20 +126,20 @@ class BugzillaCache(object):
           pass
 
     if len(bugset):
-      bzbugs = self._get_bugzilla_data(list(bugset))
-      for bzbug in bzbugs:
-        bug_whiteboard = bzbugs[bzbug].get('whiteboard', '')
-        bugs.update({bzbug: {
-                      'id': bzbug,
-                      'status': bzbugs[bzbug]['status'],
-                      'summary': bzbugs[bzbug]['summary'],
-                      'whiteboard': bug_whiteboard
-                    }})
-        self.add_or_update_bug(bzbugs[bzbug]['id'],
-                               bzbugs[bzbug]['status'],
-                               bzbugs[bzbug]['summary'],
-                               bug_whiteboard,
-                               False)
+      for bzbug in self._get_bugzilla_data(list(bugset)):
+          bug_id = bzbug['id']
+          bug_whiteboard = bzbug.get('whiteboard', '')
+          bugs[bug_id] = {
+              'id': bzbug['id'],
+              'status': bzbug['status'],
+              'summary': bzbug['summary'],
+              'whiteboard': bug_whiteboard
+          }
+          self.add_or_update_bug(bug_id,
+                                 bzbug['status'],
+                                 bzbug['summary'],
+                                 bug_whiteboard,
+                                 False)
 
     return bugs
 

--- a/bzcache/bzcache.py
+++ b/bzcache/bzcache.py
@@ -95,10 +95,17 @@ class BugzillaCache(object):
                                  False)
 
   def _get_bugzilla_data(self, bugid_array):
-    apiURL = (self.bzapi_server + "bug?id=" + ','.join(bugid_array) +
-              "&include_fields=id,summary,status,whiteboard")
-    bugdict = self.fetch_json(apiURL).get('bugs', [])
-    return bugdict
+    # request bugs from Bugzilla in groups of 200
+    chunk_size = 200
+    bugs = []
+
+    bugid_chunks = [list(bugid_array)[i:i+chunk_size]
+                    for i in range(0, len(bugid_array), chunk_size)]
+    for bugid_chunk in bugid_chunks:
+        apiURL = (self.bzapi_server + "bug?id=" + ','.join(bugid_array) +
+                  "&include_fields=id,summary,status,whiteboard")
+        bugs += self.fetch_json(apiURL).get('bugs', [])
+    return bugs
 
   def get_bugs(self, bugids):
     bugs = {}

--- a/bzcache/bzcache.py
+++ b/bzcache/bzcache.py
@@ -4,7 +4,6 @@
 
 import datetime
 import json
-import urllib
 
 import requests
 from mozautoeslib import ESLib
@@ -96,17 +95,11 @@ class BugzillaCache(object):
                                  False)
 
   def _get_bugzilla_data(self, bugid_array):
-    buginfo = {}
     retVal = {}
 
     apiURL = (self.bzapi_server + "bug?id=" + ','.join(bugid_array) +
               "&include_fields=id,summary,status,whiteboard")
-
-    jsonurl = urllib.urlopen(apiURL)
-    buginfo = jsonurl.read()
-    jsonurl.close()
-    bugdict = []
-    bugdict = json.loads(buginfo)['bugs']
+    bugdict = self.fetch_json(apiURL).get('bugs', [])
     for bug in bugdict:
         retVal[bug['id']] = bug
     return retVal

--- a/bzcache/bzcache.py
+++ b/bzcache/bzcache.py
@@ -6,6 +6,7 @@ import datetime
 import json
 import urllib
 
+import requests
 from mozautoeslib import ESLib
 
 import config
@@ -49,6 +50,16 @@ class BugzillaCache(object):
       return result['_id']
 
     raise Exception(json.dumps(result))
+
+  def fetch_json(self, url, params=None, timeout=30):
+      self.log('Fetching %s with params %s' % (url, params))
+      headers = {
+          'Accept': 'application/json',
+          'User-Agent': 'bzcache',
+      }
+      response = requests.get(url, params=params, headers=headers, timeout=timeout)
+      response.raise_for_status()
+      return response.json()
 
   def index_bugs_by_keyword(self, keyword):
     # only look at bugs that have been updated in the last 6 months

--- a/bzcache/config.py
+++ b/bzcache/config.py
@@ -1,3 +1,4 @@
+BUGZILLA_URL = 'https://bugzilla.mozilla.org'
 DEFAULT_ES_SERVER = 'of-elasticsearch-zlb.webapp.scl3.mozilla.com:9200'
-DEFAULT_BZAPI_SERVER = 'https://bugzilla.mozilla.org/bzapi/'
+DEFAULT_BZAPI_SERVER = '%s/bzapi/' % BUGZILLA_URL
 DEFAULT_OF_SERVER = 'http://brasstacks.mozilla.com/orangefactor/api/'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 version = '0.1.3'
 
-deps = ['mozautoeslib']
+deps = ['mozautoeslib', 'requests']
 
 if sys.version < '2.6' or sys.version >= '3.0':
     print >>sys.stderr, '%s requires Python >= 2.6 and < 3.0' % _PACKAGE_NAME


### PR DESCRIPTION
Stopgap to fix [bug 1301107](https://bugzilla.mozilla.org/show_bug.cgi?id=1301107). There's a lot left that could be done, but since bzcache is virtually EOL, it's not worth it.

This PR is currently running on brasstacks and seems to be working fine.

See individual commits for more details :-)